### PR TITLE
Add persistence to Kiali/Grafana/Prometheus/Jaeger

### DIFF
--- a/.env.monitoring.example
+++ b/.env.monitoring.example
@@ -1,0 +1,3 @@
+GF_ADMIN_USER=admin
+GF_ADMIN_PASSWORD=this_password_is_too_weak
+SERVER_DOMAIN=example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env*
+!.env*.example

--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ This repo is based on https://github.com/blueswen/fastapi-jaeger, which integrat
 istioctl install --set profile=demo -y
 ```
 
-2. Deploy Jaeger etc. to the namespace `istio-system` by running:
-```sh
-kubectl apply -f k8s/addons
-```
-
-3. Deploy local registry by:
+2. Deploy local registry by:
 ```sh
 docker run -d -p 5000:5000 --restart always --name registry registry:2
+```
+
+3. Create a secret:
+```sh
+cp .env.monitoring.example .env.monitoring
+vim .env.monitoring # edit this file as you like
+kubectl -n istio-system create secret generic monitoring-secret --from-env-file .env.monitoring
+```
+
+4. Deploy Jaeger etc. to the namespace `istio-system` by running:
+```sh
+kubectl apply -f k8s/addons
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -45,12 +45,32 @@ kubectl apply -f k8s
 
 4. Issue requests to the FastAPI app:
 ```sh
-curl localhost/chain
+curl http://localhost/chain
 ```
 
-5. Open Jaeger dashboard:
+
+## Observability
+
+### Grafana
+
+1. Make sure to create `monitoring-secret` in namespace `istio-system` by following the prerequisites above.
+
+2. Visit Grafana dashboard at http://localhost/grafana
+
+### Kiali
+1. Create a token:
+```sh
+kubectl -n istio-system create token kiali
+```
+
+2. Visit Kiali dashboard at http://localhost/kiali
+
+### Jaeger/Prometheus
+
+1. Open dashboard using port-forwarding:
 ```sh
 istioctl dashboard jaeger
+istioctl dashboard prometheus
 ```
 
 ## Cleanup

--- a/k8s/addons/grafana.yaml
+++ b/k8s/addons/grafana.yaml
@@ -180,15 +180,30 @@ spec:
             - name: GF_PATHS_PROVISIONING
               value: /etc/grafana/provisioning
             - name: "GF_AUTH_ANONYMOUS_ENABLED"
-              value: "true"
-            - name: "GF_AUTH_ANONYMOUS_ORG_ROLE"
-              value: "Admin"
-            - name: "GF_AUTH_BASIC_ENABLED"
               value: "false"
+            # - name: "GF_AUTH_ANONYMOUS_ORG_ROLE"
+            #   value: "Admin"
+            - name: "GF_AUTH_BASIC_ENABLED"
+              value: "true"
             - name: "GF_SECURITY_ADMIN_PASSWORD"
-              value: "-"
+              valueFrom:
+                  secretKeyRef:
+                    name: monitoring-secret
+                    key: GF_ADMIN_PASSWORD
             - name: "GF_SECURITY_ADMIN_USER"
-              value: "-"
+              valueFrom:
+                  secretKeyRef:
+                    name: monitoring-secret
+                    key: GF_ADMIN_USER
+            - name: GF_SERVER_ROOT_URL
+              value: "%(protocol)s://%(domain)s/grafana/"
+            - name: GF_SERVER_DOMAIN
+              valueFrom:
+                  secretKeyRef:
+                    name: monitoring-secret
+                    key: SERVER_DOMAIN
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: "false"
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -214,7 +229,21 @@ spec:
           configMap:
             name: istio-services-grafana-dashboards
         - name: storage
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: grafana-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: istio-system
+  name: grafana-pvc
+spec:
+  # storageClassName: local-path
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
 
 ---
 

--- a/k8s/addons/jaeger.yaml
+++ b/k8s/addons/jaeger.yaml
@@ -52,7 +52,21 @@ spec:
               cpu: 10m
       volumes:
         - name: data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: jaeger-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: istio-system
+  name: jaeger-pvc
+spec:
+  # storageClassName: local-path
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/addons/kiali.yaml
+++ b/k8s/addons/kiali.yaml
@@ -37,7 +37,7 @@ data:
       openid: {}
       openshift:
         client_id_prefix: kiali
-      strategy: anonymous
+      strategy: token
     deployment:
       accessible_namespaces:
       - '**'

--- a/k8s/addons/prometheus.yaml
+++ b/k8s/addons/prometheus.yaml
@@ -527,5 +527,18 @@ spec:
           configMap:
             name: prometheus
         - name: storage-volume
-          emptyDir:
-            {}
+          persistentVolumeClaim:
+            claimName: prometheus-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: istio-system
+  name: prometheus-pvc
+spec:
+  # storageClassName: local-path
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/k8s/istio-ingress-gateway.yml
+++ b/k8s/istio-ingress-gateway.yml
@@ -48,6 +48,18 @@ spec:
             host: grafana.istio-system.svc.cluster.local
             port:
               number: 3000
+    - match:
+        - uri:
+            exact: "/kiali"
+        - uri:
+            prefix: "/kiali/"
+      # rewrite:    # not needed
+      #   uri: "/"  # reference: https://github.com/kiali/kiali/issues/1059#issuecomment-491540360
+      route:
+        - destination:
+            host: kiali.istio-system.svc.cluster.local
+            port:
+              number: 20001
     - route:
         - destination:
             host: app-a.demo.svc.cluster.local

--- a/k8s/istio-ingress-gateway.yml
+++ b/k8s/istio-ingress-gateway.yml
@@ -36,6 +36,18 @@ spec:
   gateways:
     - demo-gateway
   http:
+    - match:
+        - uri:
+            exact: "/grafana"
+        - uri:
+            prefix: "/grafana/"
+      rewrite:
+        uri: "/"
+      route:
+        - destination:
+            host: grafana.istio-system.svc.cluster.local
+            port:
+              number: 3000
     - route:
         - destination:
             host: app-a.demo.svc.cluster.local


### PR DESCRIPTION
By declaring PVC for each observability tool, this PR adds persistence.
I verified the data collected are still shown after restarting each pod by `kubectl -n istio-system rollout restart deploy`

This PR also adds shortcut routes `/kiali` and `/grafana` to access these dashboards without using `istioctl dashboard kiali` etc.

Because these routes are accessible from anyone accessing our app, I secured those dashboards using built-in authentication: token auth for Kiali and basic auth for Grafana.